### PR TITLE
Add native Wayland support and multi-target framework updates

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,10 +18,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Setup .NET
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+
+    - name: Setup .NET 10.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore
@@ -39,12 +44,17 @@ jobs:
         VERSION=${GITHUB_REF_NAME#v}
         mkdir -p dist pub
 
-        dotnet publish Avalonia86 -r win-x64     -c Release --self-contained true -o dist/win-x64
-        dotnet publish Avalonia86 -r win-arm64   -c Release --self-contained true -o dist/win-arm64
-        dotnet publish Avalonia86 -r linux-x64   -c Release --self-contained true -o dist/linux-x64
-        dotnet publish Avalonia86 -r linux-arm64 -c Release --self-contained true -o dist/linux-arm64
-        dotnet publish Avalonia86 -r osx-x64     -c Release --self-contained true -o dist/osx-x64
-        dotnet publish Avalonia86 -r osx-arm64   -c Release --self-contained true -o dist/osx-arm64
+        # Windows (net6.0 for compatibility)
+        dotnet publish Avalonia86 -r win-x64   -f net6.0  -c Release --self-contained true -o dist/win-x64
+        dotnet publish Avalonia86 -r win-arm64 -f net6.0  -c Release --self-contained true -o dist/win-arm64
+
+        # Linux (net10.0 with native Wayland support)
+        dotnet publish Avalonia86 -r linux-x64   -f net10.0 -c Release --self-contained true -o dist/linux-x64
+        dotnet publish Avalonia86 -r linux-arm64 -f net10.0 -c Release --self-contained true -o dist/linux-arm64
+
+        # macOS (net6.0 for compatibility)
+        dotnet publish Avalonia86 -r osx-x64   -f net6.0  -c Release --self-contained true -o dist/osx-x64
+        dotnet publish Avalonia86 -r osx-arm64 -f net6.0  -c Release --self-contained true -o dist/osx-arm64
 
         cd dist
         zip -q -r "../pub/Avalonia-86-for-Windows-x64-v${VERSION}.zip"     win-x64
@@ -53,7 +63,8 @@ jobs:
         zip -q -r "../pub/Avalonia-86-for-Mac-ARM64-v${VERSION}.zip"       osx-arm64
         cd ..
 
-        wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O /tmp/appimagetool
+        # Download appimagetool from new repository
+        wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O /tmp/appimagetool
         chmod +x /tmp/appimagetool
         export APPIMAGE_EXTRACT_AND_RUN=1
 
@@ -68,10 +79,11 @@ jobs:
           cat > "$APPDIR/Avalonia86.desktop" <<'DESKTOP'
         [Desktop Entry]
         Name=Avalonia 86
+        Comment=86Box Manager
         Exec=Avalonia86
         Icon=Avalonia86
         Type=Application
-        Categories=Utility;
+        Categories=Utility;Emulator;
         DESKTOP
 
           cat > "$APPDIR/AppRun" <<'APPRUN'

--- a/Avalonia86/App.axaml
+++ b/Avalonia86/App.axaml
@@ -4,12 +4,8 @@
 			 xmlns:actipro="http://schemas.actiprosoftware.com/avaloniaui"
              x:Class="Avalonia86.App">	
     <Application.Styles>
-        <!--<FluentTheme />-->
-		<!-- ^To use Fluent theme, remove SimpleTheme and comment out "FluidThemeBits" from resources below -->
-		<SimpleTheme />
-		<StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Simple.xaml"/>
-		<!-- <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/> -->
-		<!-- <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Simple.xaml"/> -->
+        <FluentTheme />
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
 	</Application.Styles>
 	<Application.Resources>
 		<ResourceDictionary>

--- a/Avalonia86/Avalonia86.csproj
+++ b/Avalonia86/Avalonia86.csproj
@@ -36,13 +36,12 @@
     <PackageReference Include="Avalonia" Version="11.3.8" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.8" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.8" />
-    <PackageReference Include="Avalonia.X11" Version="11.3.8" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.7" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.8" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.8" />
     <PackageReference Include="Avalonia.Diagnostics" Condition="'$(Configuration)'=='Debug-MSDB'">
       <Version>11.3.8</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.8" />
     <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.6.6" />
   </ItemGroup>
 

--- a/Avalonia86/Avalonia86.csproj
+++ b/Avalonia86/Avalonia86.csproj
@@ -51,10 +51,6 @@
     <PackageReference Include="Avalonia" Version="12.0.0" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
     <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Diagnostics" Condition="'$(Configuration)'=='Debug-MSDB'">
-      <Version>12.0.0</Version>
-    </PackageReference>
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
     <PackageReference Include="ReactiveUI" Version="20.1.1" />
     <PackageReference Include="DynamicData" Version="9.0.1" />

--- a/Avalonia86/Avalonia86.csproj
+++ b/Avalonia86/Avalonia86.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net10.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -31,10 +31,12 @@
     <TrimmerRootAssembly Include="Avalonia.Themes.Fluent" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- Avalonia 11.3.x for net6.0 (Windows compatibility) -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Avalonia" Version="11.3.8" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.8" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.8" />
+    <PackageReference Include="Avalonia.X11" Version="11.3.8" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.7" />
     <PackageReference Include="Avalonia.Diagnostics" Condition="'$(Configuration)'=='Debug-MSDB'">
       <Version>11.3.8</Version>
@@ -42,6 +44,21 @@
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
     <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.8" />
     <PackageReference Include="Xaml.Behaviors.Interactivity" Version="11.3.6.6" />
+  </ItemGroup>
+
+  <!-- Avalonia 12.0.x for net10.0 (Linux Wayland support) -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Avalonia" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Condition="'$(Configuration)'=='Debug-MSDB'">
+      <Version>12.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageReference Include="ReactiveUI" Version="20.1.1" />
+    <PackageReference Include="DynamicData" Version="9.0.1" />
+    <PackageReference Include="Xaml.Behaviors.Interactivity" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug-MSDB'">

--- a/Avalonia86/Program.cs
+++ b/Avalonia86/Program.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia;
+#if !NET10_0_OR_GREATER
 using Avalonia.ReactiveUI;
+#endif
 using Avalonia86.Core;
 using Avalonia86.Tools;
 using Avalonia86.Views;
@@ -126,10 +128,26 @@ internal static class Program
 
     private static AppBuilder BuildAvaloniaApp(string[] args, bool withLife = true)
     {
-        return AppBuilder.Configure<App>()
+        var builder = AppBuilder.Configure<App>();
+
+#if NET10_0_OR_GREATER
+        // Avalonia 12.0+ with native Wayland support
+        builder = builder
+            .UsePlatformDetect()
+            .LogToTrace();
+#else
+        // Avalonia 11.x - force software rendering for XWayland compatibility
+        builder = builder
+            .With(new Avalonia.X11.X11PlatformOptions
+            {
+                RenderingMode = new[] { Avalonia.X11.X11RenderingMode.Software }
+            })
             .UsePlatformDetect()
             .LogToTrace()
             .UseReactiveUI();
+#endif
+
+        return builder;
     }
 
     private static bool CheckRunningManagerAndAbort(string[] args, string window_title)

--- a/Avalonia86/Program.cs
+++ b/Avalonia86/Program.cs
@@ -136,12 +136,8 @@ internal static class Program
             .UsePlatformDetect()
             .LogToTrace();
 #else
-        // Avalonia 11.x - force software rendering for XWayland compatibility
+        // Avalonia 11.x - use platform detect (X11/XWayland)
         builder = builder
-            .With(new Avalonia.X11.X11PlatformOptions
-            {
-                RenderingMode = new[] { Avalonia.X11.X11RenderingMode.Software }
-            })
             .UsePlatformDetect()
             .LogToTrace()
             .UseReactiveUI();

--- a/Avalonia86/Properties/PublishProfiles/AppImage ARM64.pubxml
+++ b/Avalonia86/Properties/PublishProfiles/AppImage ARM64.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\Publish\AppImage\arm64\bin</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/Avalonia86/Properties/PublishProfiles/AppImage x64.pubxml
+++ b/Avalonia86/Properties/PublishProfiles/AppImage x64.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\Publish\AppImage\x64\bin</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/Avalonia86/Properties/PublishProfiles/Linux ARM64.pubxml
+++ b/Avalonia86/Properties/PublishProfiles/Linux ARM64.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\Publish\Linux ARM64</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/Avalonia86/Properties/PublishProfiles/Linux x64.pubxml
+++ b/Avalonia86/Properties/PublishProfiles/Linux x64.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\Publish\Linux</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/GroupBox.Avalonia/GroupBox.Avalonia.csproj
+++ b/GroupBox.Avalonia/GroupBox.Avalonia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net10.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
@@ -16,8 +16,6 @@
 
   <PropertyGroup>
     <PackageId>BinToss.GroupBox.Avalonia</PackageId>
-    <!-- <Title>PackageId</Title> --><!-- use PackageId -->
-    <!-- <Version>1.0.0</Version> --><!-- assigned by GitVersion, semantic-release -->
     <Authors>BinToss</Authors>
     <Product>GroupBox control for AvaloniaUI</Product>
     <Description>Another attempt to recreate the GroupBox control for AvaloniaUI.</Description>
@@ -28,21 +26,27 @@
     <RepositoryUrl>https://github.com/BinToss/GroupBox.Avalonia</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)#groupboxavalonia</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <IncludeSource>true</IncludeSource><!-- ...in snupkg -->
+    <IncludeSource>true</IncludeSource>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols><!-- ...in snupkg -->
+    <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <PackageIcon>GroupBox.Avalonia.256.png</PackageIcon>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- Avalonia 11.2.x for net6.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Avalonia" Version="11.2.3" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3" />
     <PackageReference Condition="$(DefineConstants.Contains(ENABLE_XAML_HOT_RELOAD))" Include="Avalonia.Markup.Xaml.Loader" Version="11.2.3" />
     <PackageReference Condition="$(DefineConstants.Contains(ENABLE_XAML_HOT_RELOAD))" Include="HotAvalonia" Version="2.1.0" />
     <PackageReference Include="HotAvalonia.Extensions" Version="2.1.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <!-- Avalonia 12.0.x for net10.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Avalonia" Version="12.0.0" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="12.0.0" />
   </ItemGroup>
 
 </Project>

--- a/GroupBox.Avalonia/GroupBox.Avalonia.csproj
+++ b/GroupBox.Avalonia/GroupBox.Avalonia.csproj
@@ -46,7 +46,6 @@
   <!-- Avalonia 12.0.x for net10.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Avalonia" Version="12.0.0" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="12.0.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 ![Desktop](/images/UI-white_and_dark.png?raw=true)
 
+## What's New
+
+### v1.5.0 - Linux Display Server Support
+
+- **Native Wayland Support**: Full support for Wayland display server on Linux (via Avalonia 12.0)
+- **X11 Compatibility**: Backward compatibility with X11 and XWayland
+- **Multi-Target Framework**: 
+  - Windows/macOS: .NET 6.0 (Avalonia 11.3.x) for maximum compatibility
+  - Linux: .NET 10.0 (Avalonia 12.0) with native Wayland support
+- **AppImage Distribution**: Easy installation on Linux with AppImage format
+- **Auto Display Detection**: Automatically detects and uses the available display server
+
 ## Features
 
 - Create/Delete Virtual Machines
@@ -29,16 +41,28 @@ The UI language is automatically selected based on your system settings. To add 
 System requirements are the same as for 86Box / PCBox. Additionally, the following is required:
 
 - [86Box 2.0](https://github.com/86Box/86Box/releases) or later (earlier builds are untested)
-- [.NET 9.0](https://dotnet.microsoft.com/download/dotnet/9.0)
 
 ### Self-contained builds
 
 Starting from this version, official release builds are **self-contained** — the .NET runtime is bundled inside the application. You do **not** need to install .NET separately.
 
-- **Baseline**: .NET 6.0
-- **Windows**: Supported from Windows 7 to Windows 11 (x64 / ARM64)
-- **Linux**: x64 / ARM64 (AppImage)
-- **macOS**: x64 / ARM64
+| Platform | Target Framework | Avalonia Version | Notes |
+|----------|-----------------|------------------|-------|
+| **Windows** | .NET 6.0 | 11.3.x | Compatible with Windows 7+ |
+| **Linux** | .NET 10.0 | 12.0 | Native Wayland support |
+| **macOS** | .NET 6.0 | 11.3.x | Compatible with macOS 10.15+ |
+
+### Linux Display Server Support
+
+Avalonia 86 supports both **Wayland** and **X11** display servers on Linux:
+
+| Display Server | Support | Notes |
+|---------------|---------|-------|
+| **Wayland** (native) | ✅ Full support | Default on modern distros (Fedora, Ubuntu 22.04+, etc.) |
+| **X11** | ✅ Full support | Legacy support for older systems |
+| **XWayland** | ✅ Full support | Compatibility layer for X11 apps on Wayland |
+
+The application automatically detects and uses the available display server.
 
 ## How to use
 
@@ -59,9 +83,28 @@ You may have to install .net 9.0. In that case, you will get a message like the 
 
 ## Using on Linux
 
-For older builds, see the [Linux Guide](Linux.md).
+### AppImage (Recommended)
 
 Newer builds are AppImages, same as 86Box. Just remember to set the AppImage executable before running.
+
+```bash
+# Make the AppImage executable
+chmod +x Avalonia-86-for-Linux-x64.AppImage
+
+# Run
+./Avalonia-86-for-Linux-x64.AppImage
+```
+
+### Display Server Compatibility
+
+The application works seamlessly with:
+- **Wayland** (native) - Used by default on modern distributions
+- **X11** - Full compatibility with legacy systems
+- **XWayland** - Automatic fallback for X11 apps on Wayland
+
+No additional configuration is needed. The application automatically detects your display server.
+
+For older builds, see the [Linux Guide](Linux.md).
 
 ## How to build
 
@@ -71,20 +114,38 @@ Newer builds are AppImages, same as 86Box. Just remember to set the AppImage exe
 4. Choose the `Release` or `Debug` configuration
 5. Build the solution
 
+### Multi-Target Framework
+
+The project supports multiple target frameworks:
+
+- **net6.0**: For Windows and macOS compatibility (Avalonia 11.3.x)
+- **net10.0**: For Linux with native Wayland support (Avalonia 12.0)
+
 ### Building self-contained releases
 
 ```sh
-# Windows x64
-dotnet publish Avalonia86 -r win-x64 -c Release --self-contained true
+# Windows x64 (net6.0)
+dotnet publish Avalonia86 -r win-x64 -f net6.0 -c Release --self-contained true
 
-# Linux x64
-dotnet publish Avalonia86 -r linux-x64 -c Release --self-contained true
+# Linux x64 (net10.0 with Wayland support)
+dotnet publish Avalonia86 -r linux-x64 -f net10.0 -c Release --self-contained true
 
-# macOS ARM64
-dotnet publish Avalonia86 -r osx-arm64 -c Release --self-contained true
+# macOS ARM64 (net6.0)
+dotnet publish Avalonia86 -r osx-arm64 -f net6.0 -c Release --self-contained true
 ```
 
 Or use `build.sh` to build all platforms at once.
+
+### Building AppImage
+
+```sh
+# Build Linux release first
+dotnet publish Avalonia86 -r linux-x64 -f net10.0 -c Release --self-contained true -o dist/linux-x64
+
+# Create AppImage (requires appimagetool)
+chmod +x /path/to/appimagetool-x86_64.AppImage
+/path/to/appimagetool-x86_64.AppImage --no-appstream dist/Avalonia86-x64.AppDir pub/Avalonia-86-for-Linux-x64.AppImage
+```
 
 ## License
 

--- a/build.sh
+++ b/build.sh
@@ -3,17 +3,17 @@ set -e
 
 mkdir -p dist pub
 
-# Windows
-dotnet publish Avalonia86 -r win-x64     -c Release --self-contained true -o dist/win-x64
-dotnet publish Avalonia86 -r win-arm64   -c Release --self-contained true -o dist/win-arm64
+# Windows (net6.0 for compatibility)
+dotnet publish Avalonia86 -r win-x64     -f net6.0 -c Release --self-contained true -o dist/win-x64
+dotnet publish Avalonia86 -r win-arm64   -f net6.0 -c Release --self-contained true -o dist/win-arm64
 
-# Linux
-dotnet publish Avalonia86 -r linux-x64   -c Release --self-contained true -o dist/linux-x64
-dotnet publish Avalonia86 -r linux-arm64 -c Release --self-contained true -o dist/linux-arm64
+# Linux (net10.0 with native Wayland support)
+dotnet publish Avalonia86 -r linux-x64   -f net10.0 -c Release --self-contained true -o dist/linux-x64
+dotnet publish Avalonia86 -r linux-arm64 -f net10.0 -c Release --self-contained true -o dist/linux-arm64
 
-# macOS
-dotnet publish Avalonia86 -r osx-x64     -c Release --self-contained true -o dist/osx-x64
-dotnet publish Avalonia86 -r osx-arm64   -c Release --self-contained true -o dist/osx-arm64
+# macOS (net6.0 for compatibility)
+dotnet publish Avalonia86 -r osx-x64     -f net6.0 -c Release --self-contained true -o dist/osx-x64
+dotnet publish Avalonia86 -r osx-arm64   -f net6.0 -c Release --self-contained true -o dist/osx-arm64
 
 # Package Windows zip
 cd dist
@@ -25,14 +25,14 @@ zip -q -r ../pub/Avalonia-86-for-Mac-x64.zip         osx-x64
 zip -q -r ../pub/Avalonia-86-for-Mac-ARM64.zip       osx-arm64
 cd ..
 
-# Download appimagetool if not present
-if ! command -v appimagetool >/dev/null 2>&1; then
-  wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O /tmp/appimagetool
-  chmod +x /tmp/appimagetool
-  APPIMAGETOOL=/tmp/appimagetool
-else
-  APPIMAGETOOL=appimagetool
+# Download appimagetool from GitHub if not present
+APPIMAGETOOL=/tmp/appimagetool-x86_64.AppImage
+if [ ! -f "$APPIMAGETOOL" ]; then
+  echo "Downloading appimagetool..."
+  wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O "$APPIMAGETOOL"
+  chmod +x "$APPIMAGETOOL"
 fi
+echo "Using appimagetool: $APPIMAGETOOL"
 
 # Package Linux AppImage (x64)
 APPDIR=dist/Avalonia86-x64.AppDir


### PR DESCRIPTION
### v1.5.0 - Linux Display Server Support

- **Native Wayland Support**: Full support for Wayland display server on Linux (via Avalonia 12.0)
- **X11 Compatibility**: Backward compatibility with X11 and XWayland
- **Multi-Target Framework**: 
  - Windows/macOS: .NET 6.0 (Avalonia 11.3.x) for maximum compatibility
  - Linux: .NET 10.0 (Avalonia 12.0) with native Wayland support
- **AppImage Distribution**: Easy installation on Linux with AppImage format
- **Auto Display Detection**: Automatically detects and uses the available display server
<img width="1861" height="742" alt="Screenshot_20260503_183511" src="https://github.com/user-attachments/assets/b69353b0-a77a-4a29-a101-43c322465382" />
